### PR TITLE
feat: added sephora api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem 'omniauth-rails_csrf_protection', "~> 1.0"
 # Facebook Login
 gem 'omniauth-facebook'
 
+# API call
+gem 'excon', '~> 0.99.0'
+
 gem "autoprefixer-rails"
 gem "font-awesome-sass", "~> 6.1"
 gem "simple_form", github: "heartcombo/simple_form"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.12.0)
+    excon (0.99.0)
     execjs (2.8.1)
     faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
@@ -299,6 +300,7 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
+  excon (~> 0.99.0)
   font-awesome-sass (~> 6.1)
   jbuilder
   jsbundling-rails

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,16 +4,31 @@ class ProductsController < ApplicationController
   end
 
   def show
-    @product = Product.find(params[:id])
+      @product = Product.find(params[:id])
   end
 
   def new
     @product = Product.new
   end
 
+  def search
+    # Search method to display data returned from API w/o creating the product.
+    @product = find_product(params[:query])
+
+    # Flash alert needs to be created
+    unless @product
+      flash[:alert] = "Product not found"
+      return render action :new
+    end
+
+    # Hard coding one product in order to see if we can get the info from the API
+    # Without knowing the barcodes of certain products, it's best to hard code this to move forward w/ front-end.
+    @product = find_product_details('P258612', '1237379')
+
+  end
+
   def create
-    params = product_params
-    @product = Product.new(params)
+    @product = Product.new(product_params)
     @product.save!
     redirect_to product_path(@product)
   end
@@ -35,10 +50,35 @@ class ProductsController < ApplicationController
   end
 
   private
+  require "rubygems"
+  require "excon"
+  require "json"
+  require "open-uri"
 
   def product_params
     params.require(:product).permit(:name, :brand, :description, :retail_price,
                                     :category, :ingredients, :color, :user_rating,
                                     :bonus_points)
   end
+
+  def request_api(url)
+    response = Excon.get(
+      url,
+      headers: {
+        'X-RapidAPI-Host' => URI.parse(url).host,
+        'X-RapidAPI-Key' => ENV.fetch('RAPIDAPI_API_KEY')
+      }
+    )
+    return nil if response.status != 200
+    JSON.parse(response.body)
+  end
+
+  def find_product(barcode)
+    request_api("https://sephora.p.rapidapi.com/products/search-by-barcode?upccode=#{barcode}")
+  end
+
+  def find_product_details(product_id, sku)
+    request_api("https://sephora.p.rapidapi.com/products/detail?productId=#{product_id}&preferedSku=#{sku}")
+  end
+
 end

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,0 +1,13 @@
+<div class="container">
+  <div class="search-container">
+    <%= form_with url: search_products_path, method: :get, local: true do %>
+      <div class="form-input">
+        <%= text_field_tag :query,
+            params[:query],
+            class: "form-control rounded-3" ,
+            placeholder: "Enter the barcode" %>
+        <%= submit_tag "Search", class: "btn btn-dark rounded-3" %>
+        <% end %>
+      </div>
+  </div>
+</div>

--- a/app/views/products/search.html.erb
+++ b/app/views/products/search.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <div class="product-details">
+    <h1><%= @product['displayName'] %></h1>
+    <h2><span class="fw-light">by </span><%= @product['brand']['displayName'] %></h2>
+    <%# Inserted for mock star rating placement %>
+    <p style="font-size:2em;"><%= "⭐️" * (@product['rating'].to_i)%></p>
+    <h3><%= @product['listPrice'] %></h3>
+    <p><%= @product['longDescription'].html_safe %></p>
+    <p>Category: <%= @product['parentCategory']['displayName'] %></p>
+    <p>Ingredients: <%= @product['currentSku']['ingredientDesc'] %></p>
+  </div>
+  <button class="btn btn-dark rounded-md fw-bold m-1 p-3 fs-3">New Scan</button>
+  <button class="btn btn-dark rounded-md fw-bold m-1 p-3 fs-3">Ask For Help</button>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
     omniauth_callbacks: 'users/omniauth_callbacks'
   }
 
-  resources :products
+  resources :products do
+    collection do
+      get :search
+    end
+  end
   root to: "pages#home"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
I added the Sephora API with 2 calls: 
GET search_by_barcode
GET details

Using the first should allow us to identify the product once scanned. From there, the second will provide the extensive details that we need. You can check out the API for more details here:
https://rapidapi.com/apidojo/api/sephora/

I used [this tutorial](https://rapidapi.com/blog/how-to-use-an-api-with-ruby/) for assistance on how to do the call from the back-end when an API key is needed. I'll share the API key in Slack 🔐

<img width="198" alt="Screen Shot 2023-02-16 at 16 57 28" src="https://user-images.githubusercontent.com/59029920/219506820-645c0804-f8fa-4914-9ec0-c825c1fdf955.png">
<img width="214" alt="Screen Shot 2023-02-16 at 16 58 53" src="https://user-images.githubusercontent.com/59029920/219507020-d2625447-4bbb-4c49-aa33-05d3eccd1545.png">


There are shorter description options, but the long description is the most extensive, so maybe we want to stick with that? 