### PR TITLE
fix: brought barcode reader into the product#new view. 

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,7 +18,7 @@ class ProductsController < ApplicationController
     # Flash alert needs to be created
     unless @product
       flash[:alert] = "Product not found"
-      return render action :new
+      return render action: :new
     end
 
     # Hard coding one product in order to see if we can get the info from the API

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "bootstrap"
+import "@zxing/library@latest"

--- a/app/javascript/controllers/barcode_reader_controller.js
+++ b/app/javascript/controllers/barcode_reader_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="barcode-reader"
+export default class extends Controller {
+  connect() {
+    window.addEventListener('load', function () {
+      let selectedDeviceId;
+      const codeReader = new ZXing.BrowserMultiFormatReader()
+      console.log('ZXing code reader initialized')
+      codeReader.listVideoInputDevices()
+        .then((videoInputDevices) => {
+          const sourceSelect = document.getElementById('sourceSelect')
+          selectedDeviceId = videoInputDevices[0].deviceId
+
+          // Removed "Start" link. When the video div is clicked, scan begins.
+          document.getElementById('video').addEventListener('click', () => {
+            codeReader.decodeFromVideoDevice(selectedDeviceId, 'video', (result, err) => {
+              if (result) {
+                console.log(result)
+                document.getElementById('query').textContent = result.text
+                document.getElementById('barcode-form').submit()
+              }
+              if (err && !(err instanceof ZXing.NotFoundException)) {
+                console.error(err)
+                document.getElementById('result').textContent = err
+              }
+            })
+            console.log(`Started continous decode from camera with id ${selectedDeviceId}`)
+          })
+
+          // This reset is not really necessary. If the product isn't found, we render the product#new page again with a flash alert that
+          // the product hasn't been found.
+          document.getElementById('resetButton').addEventListener('click', () => {
+            codeReader.reset()
+            document.getElementById('result').textContent = '';
+            console.log('Reset.')
+          })
+        })
+        .catch((err) => {
+          console.error(err)
+        })
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,8 @@
 
 import { application } from "./application"
 
+import BarcodeReaderController from "./barcode_reader_controller"
+application.register("barcode-reader", BarcodeReaderController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>Illuminate</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,6 +1,32 @@
-<div class="container">
-  <div class="search-container">
-    <%= form_with url: search_products_path, method: :get, local: true do %>
+<div class="container" data-controller="barcode-reader">
+
+   <section class="container" id="scanner-content">
+      <h1 class="title">Barcode Scanner</h1>
+
+      <p>Place a barcode in front of the screen to get started.</p>
+
+      <%# <div>
+        <a class="button" id="startButton">Start</a>
+        <a class="button" id="resetButton">Reset</a>
+      </div> %>
+
+      <div>
+        <video id="video" width="500" height="500" style="border: 1px solid gray"></video>
+      </div>
+
+      <%# <div id="sourceSelectPanel" style="display:none">
+        <label for="sourceSelect">Change video source:</label>
+        <select id="sourceSelect" style="max-width:400px">
+        </select>
+      </div> %>
+
+      <label>Result:</label>
+      <pre><code id="result"></code></pre>
+    </section>
+
+    <%# This is the barcode form. Not hiding it yet so that we can see what's going on. Will be hidden from view. %>
+    <div class="search-container">
+      <%= form_with url: search_products_path, method: :get, local: true, id: "barcode-form" do %>
       <div class="form-input">
         <%= text_field_tag :query,
             params[:query],
@@ -9,5 +35,5 @@
         <%= submit_tag "Search", class: "btn btn-dark rounded-3" %>
         <% end %>
       </div>
+    </div>
   </div>
-</div>


### PR DESCRIPTION
As mentioned in Slack, I brought the barcode reader into the product#new view so that it can happen in the correct place. The next action will be a product#search page with product details if found OR a refreshed product#new page with an error alert if not. 

I've left the form on the page temporarily so that we can troubleshoot, but this will be hidden from view once we have a better idea of how this will work. 

<img width="1508" alt="Screen Shot 2023-02-19 at 15 02 12" src="https://user-images.githubusercontent.com/59029920/219972309-0c0675e4-0720-45d1-9d93-f2fce35f9efa.png">
<img width="1509" alt="Screen Shot 2023-02-19 at 15 01 54" src="https://user-images.githubusercontent.com/59029920/219972310-5a741399-6477-4adb-b0da-24e32b9bba0a.png">
