### PR TITLE
fix: added fontawesome stars and did some cleanup on the show page

### DIFF
--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,6 +1,7 @@
 // Import page-specific CSS files here.
 @import "home";
 @import "products_new";
+@import "products_show";
 
 
 .container {

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,8 +18,8 @@ class ProductsController < ApplicationController
     else
       @product = find_product(params[:query])
       @product = find_product_details(@product['productId'], @product['skuId'])
-      @product = Product.new(name: @product['displayName'] , brand: @product['brand']['displayName'], description: @product['shortDescription'],
-                             ingredients: @product['currentSku']['ingredientDesc'], retail_price: @product['currentSku']['listPrice'],
+      @product = Product.new(name: @product['displayName'] , brand: @product['brand']['displayName'], description: @product['shortDescription'].gsub!('<br><br>','<br>'),
+                             ingredients: @product['currentSku']['ingredientDesc'].gsub!('<br><br>','<br>'), retail_price: @product['currentSku']['listPrice'],
                              category: @product['parentCategory']['displayName'], user_rating: @product['rating'], barcode: params[:query])
       # Flash alert needs to be created
       if @product.save

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,15 +1,16 @@
 <div class="container">
   <div class="product-details">
-    <h1><%= @product.name %></h1>
-    <h2><span class="fw-light">by </span><%= @product.brand %></h2>
+    <h1><%= @product.name.titleize %></h1>
+    <h2><span class="fw-light">by </span><%= @product.brand.titleize %></h2>
     <%# Inserted for mock star rating placement %>
-    <p style="font-size:2em;"><%= "⭐️" * (@product.user_rating)%></p>
-    <h3><%= @product.retail_price %></h3>
+    <% (@product.user_rating.to_i).times do %>
+      <i class="fa-solid fa-star fs-2" style="color:#ffcc00;"></i>
+    <% end %>
+    <h3 class="mt-3"><%= @product.retail_price %></h3>
     <p><%= @product.description.html_safe %></p>
-    <p>Category: <%= @product.category %></p>
-    <p>Color: <%= @product.color %></p>
-    <p>Ingredients: <%= @product.ingredients.html_safe %></p>
-    <p>Bonus Points: <%= @product.bonus_points %></p>
+    <p><strong>Category:</strong> <%= @product.category %></p>
+    <p><strong>Color:</strong> <%= @product.color.nil? ? "Unavailable" : @product.color %></p>
+    <p><strong>Ingredients:</strong> <%= @product.ingredients.html_safe %></p>
   </div>
   <button class="btn btn-dark rounded-md fw-bold m-1 p-3 fs-3">New Scan</button>
   <button class="btn btn-dark rounded-md fw-bold m-1 p-3 fs-3">Ask For Help</button>

--- a/db/migrate/20230225125208_change_retail_price_to_string_in_products.rb
+++ b/db/migrate/20230225125208_change_retail_price_to_string_in_products.rb
@@ -1,0 +1,5 @@
+class ChangeRetailPriceToStringInProducts < ActiveRecord::Migration[7.0]
+  def change
+    change_column :products, :retail_price, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_24_155150) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_25_125208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_24_155150) do
     t.string "name"
     t.string "brand"
     t.text "description"
-    t.decimal "retail_price"
+    t.string "retail_price"
     t.string "category"
     t.text "ingredients"
     t.string "color"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ puts "Creating one product"
 Product.create!(name: "All Day Foundation", brand: "Estée Lauder",
                 description: "This medium coverage foundation can be worn up to 8 hours with no smudging.
                               Coming in 32 shades, you'll be able to find your perfect match.",
-                retail_price: 40.00, category: "Makeup", color: "Sienna", ingredients: "Water, Oil, Cream",
+                retail_price: '$40.00', category: "Makeup", color: "Sienna", ingredients: "Water, Oil, Cream",
                 user_rating: 0, bonus_points: "No Animal Testing")
 
 puts "Product created."


### PR DESCRIPTION
Some slight issues with the original description and having too many HTML breaks that created large spaces...I think I may instead sub the breaks for span classes that insert padding in the future, because now there isn't enough spacing :(

<img width="193" alt="Screen Shot 2023-02-25 at 07 58 35" src="https://user-images.githubusercontent.com/59029920/221358265-ddeaf651-4630-4199-82d8-0afedecd5417.png">

Used #titleize for the brand name and product name. Adjusted the stars using a fontawesome icon and changed the retail price to a string to match the API call response.
