### PR TITLE
hidden the individual letters of the title for screen readers

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,17 +1,17 @@
 <div class="container">
   <div id="page-one" class="homepage">
-    <h1 class="headline">
-      <span class="letter">I</span>
-      <span class="letter">l</span>
-      <span class="letter">l</span>
-      <span class="letter">u</span>
-      <span class="letter">m</span>
-      <span class="letter">i</span>
-      <span class="letter">n</span>
-      <span class="letter">a</span>
-      <span class="letter">t</span>
-      <span class="letter">e</span>
-    </h1>
+<h1 class="headline" aria-label="illuminate">
+  <span class="letter" aria-hidden="true">I</span>
+  <span class="letter" aria-hidden="true">l</span>
+  <span class="letter" aria-hidden="true">l</span>
+  <span class="letter" aria-hidden="true">u</span>
+  <span class="letter" aria-hidden="true">m</span>
+  <span class="letter" aria-hidden="true">i</span>
+  <span class="letter" aria-hidden="true">n</span>
+  <span class="letter" aria-hidden="true">a</span>
+  <span class="letter" aria-hidden="true">t</span>
+  <span class="letter" aria-hidden="true">e</span>
+</h1>
 
     <h2 class="text-center tagline">Enhancing the beauty journey for all.</h2>
     <button type="button" class="btn btn-dark rounded-sm learn-btn">Learn more</button>


### PR DESCRIPTION
I've added an aria-hidden label to individual letters of the 'Illuminate' homepage title, so that they are not read one by one by a screen reader. 