### PR TITLE
fix: camera video should now fill the video container

### DIFF
--- a/app/assets/stylesheets/components/_video.scss
+++ b/app/assets/stylesheets/components/_video.scss
@@ -1,6 +1,7 @@
 #video {
   position: relative;
-  width: 95vw;
+  object-fit: cover;
+  width: 100vw;
   height: 100vh;
   border: 1px solid black;
   border-radius: 4em;


### PR DESCRIPTION
The video should now fill the video container instead of leaving space :)