### PR TITLE
Revert "fix: removed cssbundling gem and build:css script"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
-# gem "cssbundling-rails"
+gem "cssbundling-rails"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
+    cssbundling-rails (1.1.2)
+      railties (>= 6.0.0)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
@@ -297,6 +299,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap
   capybara
+  cssbundling-rails
   debug
   devise
   dotenv-rails

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "webpack-cli": "^5.0.1"
   },
   "scripts": {
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "build:css": "sass ./app/assets/stylesheets/application.scss"
   }
 }


### PR DESCRIPTION
Reverts SIFAR101/Illuminate#56

The CSS was fine, but the JS was not compiled.