### PR TITLE
fix: removed css bundling and replaced with dartsass rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
-gem "cssbundling-rails"
+# gem "cssbundling-rails"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
@@ -45,8 +45,8 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# Use Sass to process CSS
-gem "sassc-rails"
+# # Use Sass to process CSS
+# gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
@@ -96,3 +96,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
+
+gem "dartsass-rails", "~> 0.4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.0)
     crass (1.0.6)
-    cssbundling-rails (1.1.2)
+    dartsass-rails (0.4.1)
       railties (>= 6.0.0)
     date (3.3.3)
     debug (1.7.1)
@@ -239,12 +239,6 @@ GEM
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (4.8.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -262,7 +256,6 @@ GEM
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
-    tilt (2.0.11)
     timeout (0.3.1)
     turbo-rails (1.3.3)
       actionpack (>= 6.0.0)
@@ -299,7 +292,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap
   capybara
-  cssbundling-rails
+  dartsass-rails (~> 0.4.1)
   debug
   devise
   dotenv-rails
@@ -315,7 +308,6 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.2)
   redis (~> 4.0)
-  sassc-rails
   selenium-webdriver
   simple_form!
   sprockets-rails

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: unset PORT && bin/rails server
 js: yarn build --watch
+css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,3 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
 //= link_tree ../builds
 //= link manifest.json


### PR DESCRIPTION
I took out the sassc-rails gem which seems to be deprecated. I also took at cssbundling and replaced with dartsass-rails...I hope this doesn't affect the JS. In LocalHost, it works, but not sure about render.