### PR TITLE
fix: updated assistance controller to return the nearest sephora stores.

### DIFF
--- a/app/assets/stylesheets/pages/_products_show.scss
+++ b/app/assets/stylesheets/pages/_products_show.scss
@@ -62,7 +62,6 @@ ul.product-menu {
 }
 a.btn.btn-primary {
   background: linear-gradient(176deg, rgba(13,110,253,1) 43%, rgba(15,105,237,1) 100%);
-  width: 170px;
   height: auto;
   margin: .5em;
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -39,7 +39,7 @@ export default class extends Controller {
   //     })
   // }
   connect() {
-    console.log('Google Maps controller v5 is loaded.')
+    console.log('Google Maps controller v6 is loaded.')
     const loader = new Loader({
       apiKey: this.apiKeyValue,
       version: "weekly",
@@ -64,7 +64,6 @@ export default class extends Controller {
               lat: position.coords.latitude,
               lng: position.coords.longitude,
             };
-            map.setCenter(userPos);
           },
           () => { handleLocationError(true, infoWindow, map.getCenter()); }
         );
@@ -100,17 +99,16 @@ export default class extends Controller {
                 map,
                 position: place.geometry.location,
               })
-              google.maps.event.addListener(marker, "click", () => {
-                const content =
-                `<div class="infoWindow">
-                  <h3>Sephora</h3>
-                  <h3 class="fw-light text-primary"><a class="text-primary" href="tel:${place.formatted_phone_number}"><i class="fa-solid fa-phone fs-4 text-primary"></i> ${place.formatted_phone_number}</a></h3>
-                  <h4 class="fw-light">${place.formatted_address}</h4>
-                </div>`
+              map.setCenter(marker)
+              const content =
+              `<div class="infoWindow">
+                <h3>Sephora</h3>
+                <h3 class="fw-light text-primary"><a class="text-primary" aria-label="Call this Sephora location." href="tel:${place.formatted_phone_number}"><i class="fa-solid fa-phone fs-4 text-primary"></i> ${place.formatted_phone_number}</a></h3>
+                <h4 class="fw-light">${place.formatted_address}</h4>
+              </div>`
 
-                infoWindow.setContent(content);
-                infoWindow.open(map, marker);
-              });
+              infoWindow.setContent(content);
+              infoWindow.open(map, marker);
             }
           });
         }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   }
 
   connect() {
-    console.log("sortable controller connected")
+    console.log("Map controller v6 connected")
     mapboxgl.accessToken = this.apiKeyValue
 
     const map = new mapboxgl.Map({
@@ -19,8 +19,7 @@ export default class extends Controller {
       zoom: 1 // starting zoom
       });
 
-    map.addControl(
-      new mapboxgl.GeolocateControl({
+    const geolocate = new mapboxgl.GeolocateControl({
       positionOptions: {
       enableHighAccuracy: true
       },
@@ -29,23 +28,22 @@ export default class extends Controller {
       // Draw an arrow next to the location dot to indicate which direction the device is heading.
       showUserHeading: true
       })
-    );
+
+      map.addControl(geolocate);
+
+      geolocate.on('geolocate', (e) => {
+        const userCoords = [e.coords.longitude, e.coords.latitude]
+        console.log('coords', userCoords)
+        this.fetchStores(userCoords[0], userCoords[1])
+
+      })
   }
 
-  fetchStores() {
-    const options = {
-      method: 'GET',
-      headers: {
-        'X-RapidAPI-Key': 'a7fa530355mshba4e0f21281f064p1daf8fjsn38e1d307e269',
-        'X-RapidAPI-Host': 'sephora.p.rapidapi.com'
-      }
-    };
+  fetchStores(lng, lat) {
 
-    fetch('https://sephora.p.rapidapi.com/stores/list?latitude=33.9733&longitude=-118.2487&radius=25', options)
+    fetch(`https://api.mapbox.com/geocoding/v5/mapbox.places/sephora.json?proximity=${lng},${lat}&access_token=${mapboxgl.accessToken}`)
 	    .then(response => response.json())
 	    .then(response => console.log(response))
 	    .catch(err => console.error(err));
   }
-
-  fetchStores()
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { Loader } from "@googlemaps/js-api-loader"
 
 // Connects to data-controller="map"
 export default class extends Controller {
@@ -6,38 +7,141 @@ export default class extends Controller {
     apiKey: String,
     // markers: Array this is an unused function right now
   }
+  // connect() {
+  //   console.log("Map controller v6 connected")
+  //   mapboxgl.accessToken = this.apiKeyValue
 
+  //   const map = new mapboxgl.Map({
+  //     container: 'map', // container ID
+  //     // Choose from Mapbox's core styles, or make your own style with Mapbox Studio
+  //     style: 'mapbox://styles/mapbox/streets-v12', // style URL
+  //     center: [-24, 42], // starting center in [lng, lat]
+  //     zoom: 1 // starting zoom
+  //     });
+
+  //   const geolocate = new mapboxgl.GeolocateControl({
+  //     positionOptions: {
+  //     enableHighAccuracy: true
+  //     },
+  //     // When active the map will receive updates to the device's location as it changes.
+  //     trackUserLocation: true,
+  //     // Draw an arrow next to the location dot to indicate which direction the device is heading.
+  //     showUserHeading: true
+  //     })
+
+  //     map.addControl(geolocate);
+
+  //     geolocate.on('geolocate', (e) => {
+  //       const userCoords = [e.coords.longitude, e.coords.latitude]
+  //       console.log('coords', userCoords)
+  //       this.fetchStores(userCoords[0], userCoords[1])
+
+  //     })
+  // }
   connect() {
-    console.log("Map controller v6 connected")
-    mapboxgl.accessToken = this.apiKeyValue
+    console.log('Google Maps controller v5 is loaded.')
+    const loader = new Loader({
+      apiKey: this.apiKeyValue,
+      version: "weekly",
+      libraries: ["places"]
+    })
+    loader.load().then(() => {
+      this.initMap()
+    })
+  }
 
-    const map = new mapboxgl.Map({
-      container: 'map', // container ID
-      // Choose from Mapbox's core styles, or make your own style with Mapbox Studio
-      style: 'mapbox://styles/mapbox/streets-v12', // style URL
-      center: [-24, 42], // starting center in [lng, lat]
-      zoom: 1 // starting zoom
-      });
+  initMap() {
+    const infoWindow = new google.maps.InfoWindow();
+    const map = new google.maps.Map(document.getElementById("map"), {
+      center: { lat: -24 , lng: 42 },
+      zoom: 14
+    });
+      // Try HTML5 geolocation.
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            const userPos = {
+              lat: position.coords.latitude,
+              lng: position.coords.longitude,
+            };
+            map.setCenter(userPos);
+          },
+          () => { handleLocationError(true, infoWindow, map.getCenter()); }
+        );
+      } else {
+        // Browser doesn't support Geolocation
+        handleLocationError(false, infowWindow, map.getCenter());
+      }
+    const request = { query: 'Sephora', fields: ['place_id', 'name', 'geometry'] }
+    const service = new google.maps.places.PlacesService(map);
+    service.findPlaceFromQuery(request, (results, status) => {
+        if (status === google.maps.places.PlacesServiceStatus.OK){
+          for (var i= 0; i < results.length; i++){
+            console.log('results', results)
+            this.createMarker(results[i], map);
+          }
+          const nearestStore = results[0]
 
-    const geolocate = new mapboxgl.GeolocateControl({
-      positionOptions: {
-      enableHighAccuracy: true
-      },
-      // When active the map will receive updates to the device's location as it changes.
-      trackUserLocation: true,
-      // Draw an arrow next to the location dot to indicate which direction the device is heading.
-      showUserHeading: true
-      })
+          map.setCenter(nearestStore.geometry.location)
+          const storeDetailsRequest =  {
+            placeId: nearestStore.place_id,
+            fields: ['name', 'rating', 'formatted_phone_number','formatted_address', 'geometry']
+          };
 
-      map.addControl(geolocate);
+          service.getDetails(storeDetailsRequest, (place, status) => {
+            console.log('details', place)
+            if (
+              status === google.maps.places.PlacesServiceStatus.OK &&
+              place &&
+              place.geometry &&
+              place.geometry.location
+            ) {
+              const marker = new google.maps.Marker({
+                map,
+                position: place.geometry.location,
+              })
+              google.maps.event.addListener(marker, "click", () => {
+                const content =
+                `<div class="infoWindow">
+                  <h3>Sephora</h3>
+                  <h3 class="fw-light text-primary"><a class="text-primary" href="tel:${place.formatted_phone_number}"><i class="fa-solid fa-phone fs-4 text-primary"></i> ${place.formatted_phone_number}</a></h3>
+                  <h4 class="fw-light">${place.formatted_address}</h4>
+                </div>`
 
-      geolocate.on('geolocate', (e) => {
-        const userCoords = [e.coords.longitude, e.coords.latitude]
-        console.log('coords', userCoords)
-        this.fetchStores(userCoords[0], userCoords[1])
-
+                infoWindow.setContent(content);
+                infoWindow.open(map, marker);
+              });
+            }
+          });
+        }
       })
   }
+
+  createMarker(place, map) {
+    const infoWindow = new google.maps.InfoWindow()
+    console.log(place.geometry)
+    if (!place.geometry || !place.geometry.location) return;
+    const marker = new google.maps.Marker({
+      map,
+      position: place.geometry.location,
+    });
+
+    google.maps.event.addListener(marker, "click", () => {
+      infoWindow.setContent(place.name || "");
+      infoWindow.open(map);
+    });
+  }
+
+  handleLocationError(browserHasGeolocation, infoWindow, pos) {
+    infoWindow.setPosition(pos);
+    infoWindow.setContent(
+      browserHasGeolocation
+        ? "Error: The Geolocation service failed."
+        : "Error: Your browser doesn't support geolocation."
+    );
+    infoWindow.open(map);
+  }
+
 
   fetchStores(lng, lat) {
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
     <%= csp_meta_tag %>
     <link href="https://api.mapbox.com/mapbox-gl-js/v2.11.0/mapbox-gl.css" rel="stylesheet">
     <script src="https://api.mapbox.com/mapbox-gl-js/v2.11.0/mapbox-gl.js"></script>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js"></script>

--- a/app/views/products/assistance.html.erb
+++ b/app/views/products/assistance.html.erb
@@ -1,5 +1,13 @@
-<div id="map" style="width: 100%; height: 600px;"
-  data-controller="map"
-  data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>"></div>
+<div class="container">
+  <div id="map" style="width: 100%; height: 600px;"
+    data-controller="map"
+    data-map-api-key-value="<%= ENV['GOOGLE_MAP_API_KEY'] %>"></div>
 
-<div></div>
+    <!--
+        The `defer` attribute causes the callback to execute after the full HTML
+        document has been parsed. For non-blocking uses, avoiding race conditions,
+        and consistent behavior across browsers, consider loading using Promises
+        with https://www.npmjs.com/package/@googlemaps/js-api-loader.
+        -->
+  <div></div>
+</div>

--- a/app/views/products/assistance.html.erb
+++ b/app/views/products/assistance.html.erb
@@ -1,13 +1,4 @@
-<div class="container">
-  <div id="map" style="width: 100%; height: 600px;"
-    data-controller="map"
-    data-map-api-key-value="<%= ENV['GOOGLE_MAP_API_KEY'] %>"></div>
-
-    <!--
-        The `defer` attribute causes the callback to execute after the full HTML
-        document has been parsed. For non-blocking uses, avoiding race conditions,
-        and consistent behavior across browsers, consider loading using Promises
-        with https://www.npmjs.com/package/@googlemaps/js-api-loader.
-        -->
-  <div></div>
+<div id="map" style="width: 100vw; height: 100vh; margin-top: -3vh;"
+  data-controller="map"
+  data-map-api-key-value="<%= ENV['GOOGLE_MAP_API_KEY'] %>">
 </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -22,7 +22,7 @@
           </button>
         </h2>
         <div id="flush-collapseOne" class="accordion-collapse collapse" aria-labelledby="flush-headingOne" data-bs-parent="#accordionFlushExample">
-          <div class="accordion-body"><%= @product.description.nil? ? "Ask store associate" : @product.description.html_safe %></div>
+          <div class="accordion-body"><%= @product.description.nil? ? (link_to "Ask store associate", products_assistance_path, class:"text-primary") : @product.description.html_safe %></div>
         </div>
       </div>
       <div class="accordion-item">
@@ -32,7 +32,7 @@
           </button>
         </h2>
         <div id="flush-collapseTwo" class="accordion-collapse collapse" aria-labelledby="flush-headingTwo" data-bs-parent="#accordionFlushExample">
-          <div class="accordion-body"><%= @product.how_to.nil? ? "Ask store associate" : @product.how_to.html_safe %></div>
+          <div class="accordion-body"><%= @product.how_to.nil? ? (link_to "Ask store associate", products_assistance_path, class:"text-primary") : @product.how_to.html_safe %></div>
         </div>
       </div>
       <div class="accordion-item">
@@ -42,7 +42,7 @@
           </button>
         </h2>
         <div id="flush-collapseThree" class="accordion-collapse collapse" aria-labelledby="flush-headingThree" data-bs-parent="#accordionFlushExample">
-          <div class="accordion-body"><%= @product.benefits.nil? ? "Ask store associate" : @product.benefits.html_safe %></div>
+          <div class="accordion-body"><%= @product.benefits.nil? ? (link_to "Ask store associate", products_assistance_path, class:"text-primary") : @product.benefits.html_safe %></div>
         </div>
       </div>
       <div class="accordion-item">
@@ -52,7 +52,7 @@
           </button>
         </h2>
         <div id="flush-collapseFour" class="accordion-collapse collapse" aria-labelledby="flush-headingFour" data-bs-parent="#accordionFlushExample">
-          <div class="accordion-body"><%= @product.ingredients.nil? ? "Ask store associate" : @product.ingredients.html_safe %></div>
+          <div class="accordion-body"><%= @product.ingredients.nil? ? (link_to "Ask store associate", products_assistance_path, class:"text-primary") : @product.ingredients.html_safe %></div>
         </div>
       </div>
 
@@ -63,14 +63,14 @@
           </button>
         </h2>
         <div id="flush-collapseFive" class="accordion-collapse collapse" aria-labelledby="flush-headingFive" data-bs-parent="#accordionFlushExample">
-          <div class="accordion-body"><%= @product.bonus_points.nil? ? "Ask store associate" : @product.bonus_points.html_safe %></div>
+          <div class="accordion-body"><%= @product.bonus_points.nil? ? (link_to "Ask store associate", products_assistance_path, class:"text-primary") : @product.bonus_points.html_safe %></div>
         </div>
       </div>
       </div>
   </div>
 
   <div class="buttons d-flex flex-row justify-content-center">
-    <%= link_to 'New Scan', new_product_path, class: "btn btn-primary fs-2" %>
-    <%= link_to 'Ask for Help', root_path, class: "btn btn-primary fs-2" %>
+    <%= link_to 'New Scan', new_product_path, class: "btn btn-primary btn-lg" %>
+    <%= link_to 'Ask for Help', products_assistance_path, class: "btn btn-primary btn-lg" %>
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -23,6 +23,10 @@
           <li class="nav-item">
             <%= link_to "Scan", new_product_path, class: "nav-link" %>
           </li>
+          <li class="nav-item">
+            <%= link_to "Assistance", products_assistance_path, class: "nav-link" %>
+          </li>
+
           <li class="nav-item dropdown">
             <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
             <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": "true",
   "dependencies": {
     "@ericblade/quagga2": "^1.8.2",
+    "@googlemaps/js-api-loader": "^1.15.1",
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.2.5",
     "@popperjs/core": "^2.11.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,13 @@
   optionalDependencies:
     fsevents "2.3.2"
 
+"@googlemaps/js-api-loader@^1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz#7d5f1d55a4ec5c99b1d8f0708f3a46b83a71384c"
+  integrity sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
 "@hotwired/stimulus-webpack-helpers@^1.0.0":
   version "1.0.1"
   resolved "https://registry.npmjs.org/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz"
@@ -547,7 +554,7 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
We're now pulling the closest Sephora stores using Mapbox. I think the Sephora Stores API was only providing US stores or something weird like that. I was going to use Foursquare to find store details, but it looks like they may not provide a phone number, so I'll see if Google has something useful.

I'll be working to call the first of these stores which should be the closest one to the user once I figure out how to find all the store details.