### PR TITLE
Made product cards responsive and added buttons

### DIFF
--- a/app/assets/stylesheets/pages/_user_favorites.scss
+++ b/app/assets/stylesheets/pages/_user_favorites.scss
@@ -18,3 +18,12 @@
     }
   }
 }
+
+
+
+.card-title,
+.card-subtitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/app/views/products/user_favorites.html.erb
+++ b/app/views/products/user_favorites.html.erb
@@ -1,12 +1,30 @@
 <div class="container py-5">
   <h1 class="py-4">My Favorites</h1>
-  <div class="favorite-cards">
+  <div class="row favorite-cards m-3">
     <% if @products.any? %>
       <% @products.each do |product| %>
-       <%= render 'shared/card', product: product %>
+        <div class="col-sm-12 col-md-6 col-lg-4">
+          <%= link_to product_path(product) do %>
+            <div class="card rounded-3">
+              <img src="<%= product.image_url %>" class="card-img-top rounded-circle w-50 align-self-center" alt="<%= product.alt_text %>">
+              <div class="card-body">
+                <div class="card-title fs-5"><strong><%= product.name.titleize %></strong></div>
+                <div class="card-subtitle"><%= product.brand.titleize %></p></div>
+              </div>
+            </div>
+          <% end %>
+        </div>
       <% end %>
     <% else %>
       <p>You haven't favorited any products yet.</p>
     <% end %>
   </div>
+
+
+  <div class="buttons d-flex flex-row justify-content-center py-3">
+    <%= link_to 'New Scan', new_product_path, class: "btn btn-primary btn-lg" %>
+    <%= link_to 'Ask for Help', products_assistance_path, class: "btn btn-primary btn-lg" %>
+  </div>
+</div>
+
 </div>

--- a/app/views/shared/_card.html.erb
+++ b/app/views/shared/_card.html.erb
@@ -1,5 +1,5 @@
 <%= link_to product_path(product) do %>
-  <div class="card rounded-3" style="width: 20rem;">
+  <div class="card rounded-3">
     <img src="<%= product.image_url %>" class="card-img-top rounded-circle w-50 align-self-center" alt="<%= product.alt_text %>">
     <div class="card-body">
       <div class="card-title fs-5"><strong><%= product.name.titleize %></strong></div>


### PR DESCRIPTION
Product favorite cards weren't fully responsive and were changing size due to different title lengths. They should be ok now! 
![Screenshot 2023-03-17 at 15 14 21](https://user-images.githubusercontent.com/105730964/225930361-e84b776d-96ef-4f64-9502-ec8f5b3a51ca.png)
![Screenshot 2023-03-17 at 15 14 44](https://user-images.githubusercontent.com/105730964/225930372-e1ad2371-1a35-42a9-a4d1-922f00b16d8a.png)
![Screenshot 2023-03-17 at 15 14 48](https://user-images.githubusercontent.com/105730964/225930375-4027fe6a-30c7-4e97-b8a6-ad4192ec9106.png)
