### PR TITLE
Improve accessibility 2

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -102,9 +102,14 @@ export default class extends Controller {
               map.setCenter(marker)
               const content =
               `<div class="infoWindow">
-                <h3>Sephora</h3>
+              <span class="sr-only">You are currently in the following store: </span>
+              <h3>Sephora</h3>
+              <span class="sr-only">Located in </span>
+              <h4 class="fw-light ">${place.formatted_address}</h4>
+              <span class="sr-only">To call for assistance, please press on the following phone number button: </span>
                 <h3 class="fw-light text-primary"><a class="text-primary" aria-label="Call this Sephora location." href="tel:${place.formatted_phone_number}"><i class="fa-solid fa-phone fs-4 text-primary"></i> ${place.formatted_phone_number}</a></h3>
-                <h4 class="fw-light">${place.formatted_address}</h4>
+
+
               </div>`
 
               infoWindow.setContent(content);
@@ -148,4 +153,6 @@ export default class extends Controller {
 	    .then(response => console.log(response))
 	    .catch(err => console.error(err));
   }
+
+
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -36,7 +36,10 @@
       that can save the product to their account.</p>
 
       <p class="paragraph-intro" data-sr="enter left, move 30px, over 1s, wait 0.7s">If a user needs assistance, they can call the beauty store directly
-      from the app to speak with an employee. It's really that easy! If you'd like to get your products on Illuminate, <a class="text-primary" href="mailto:hello@dari.codes" target="_blank">get in touch!</a></p>
+      from the app to speak with an employee. It's really that easy! If you'd like to get your products on Illuminate, <a class="text-primary" href="mailto:hello@dari.codes" target="_blank"> get in touch</a><span class='sr-only'> at hello@dari.code'</span>!</p>
+
+
     </div>
+
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -36,7 +36,7 @@
       that can save the product to their account.</p>
 
       <p class="paragraph-intro" data-sr="enter left, move 30px, over 1s, wait 0.7s">If a user needs assistance, they can call the beauty store directly
-      from the app to speak with an employee. It's really that easy! If you'd like to get your products on Illuminate, <a class="text-primary" href="mailto:hello@dari.codes" target="_blank"> get in touch</a><span class='sr-only'> at hello@dari.code'</span>!</p>
+      from the app to speak with an employee. It's really that easy! If you'd like to get your products on Illuminate, <a class="text-primary" href="mailto:hello@dari.codes" target="_blank"> get in touch</a><span class='sr-only'> at hello@dari.codes'</span>!</p>
 
 
     </div>

--- a/app/views/products/assistance.html.erb
+++ b/app/views/products/assistance.html.erb
@@ -1,4 +1,4 @@
-        <p class="sr-only">Your position was detected successfully..</p>
+        <p class="sr-only">Detecting your location...</p>
 <div id="map" style="width: 100vw; height: 100vh;"
   data-controller="map"
   data-map-api-key-value="<%= ENV['GOOGLE_MAP_API_KEY'] %>">

--- a/app/views/products/assistance.html.erb
+++ b/app/views/products/assistance.html.erb
@@ -1,3 +1,4 @@
+        <p class="sr-only">Your position was detected successfully..</p>
 <div id="map" style="width: 100vw; height: 100vh;"
   data-controller="map"
   data-map-api-key-value="<%= ENV['GOOGLE_MAP_API_KEY'] %>">

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -2,7 +2,7 @@
 <div class="container" data-controller="barcode-reader" aria-label='The scanner is active. Place a product in front of your camera and turn it slowly to allow your phone to detect it.'>
   <section class="container" id="scanner-content">
     <div id="video-container">
-      <video id="video"></video>
+      <video id="video" aria-label='Scanner area'></video>
     </div>
   </section>
 

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -7,7 +7,7 @@
   </section>
 
   <div class="search-container">
-    <h4 id="scan-info" class="animate__animated animate__flash animate__slower animate__infinite" aria-label='scanning in progress'>
+    <h4 id="scan-info" class="animate__animated animate__flash animate__slower animate__infinite" aria-label='Scanning in progress.'>
         <i class="fa-solid fa-qrcode"></i><br/>Scanning</h4>
         <p class="sr-only">Place the product in front of the camera and rotate it slowly to find the QR code.</p>
         <p class="sr-only">If no product is found, you can call for assistance using the button below.</p>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -7,15 +7,22 @@
   </section>
 
   <div class="search-container">
-    <h4 id="scan-info" class="animate__animated animate__flash animate__slower animate__infinite">
+    <h4 id="scan-info" class="animate__animated animate__flash animate__slower animate__infinite" aria-label='scanning in progress'>
         <i class="fa-solid fa-qrcode"></i><br/>Scanning</h4>
+        <p class="sr-only">Place the product in front of the camera and rotate it slowly to find the QR code.</p>
+        <p class="sr-only">If no product is found, you can call for assistance using the button below.</p>
+        <%= link_to "Call for Assistance", products_assistance_path, class: "btn btn-dark rounded-3 mt-2", style: 'margin-left: 1vw;' %>
+
+
     <%= form_with url: search_products_path, method: :get, local: true, id: "barcode-form" do %>
     <div class="form-input d-flex flex-column align-items-center">
       <%= text_field_tag :query,
           params[:query],
           class: "form-control rounded-3" %>
       <%= submit_tag "Search", class: "btn btn-dark rounded-3 mt-2" %>
+
       <% end %>
+
     </div>
   </div>
 </div>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -11,7 +11,7 @@
         <i class="fa-solid fa-qrcode"></i><br/>Scanning</h4>
         <p class="sr-only">Place the product in front of the camera and rotate it slowly to find the QR code.</p>
         <p class="sr-only">If no product is found, you can call for assistance using the button below.</p>
-        <%= link_to "Call for Assistance", products_assistance_path, class: "btn btn-dark rounded-3 mt-2", style: 'margin-left: 1vw;' %>
+        <%= link_to "Call for Assistance", products_assistance_path, class: "btn btn-dark rounded-3 mt-2 visually-hidden", style: 'margin-left: 1vw;' %>
 
 
     <%= form_with url: search_products_path, method: :get, local: true, id: "barcode-form" do %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -11,7 +11,8 @@
         <i class="fa-solid fa-qrcode"></i><br/>Scanning</h4>
         <p class="sr-only">Place the product in front of the camera and rotate it slowly to find the QR code.</p>
         <p class="sr-only">If no product is found, you can call for assistance using the button below.</p>
-        <%= link_to "Call for Assistance", products_assistance_path, class: "btn btn-dark rounded-3 mt-2 visually-hidden", style: 'margin-left: 1vw;' %>
+<%= link_to "Call for Assistance", products_assistance_path, class: "btn btn-dark rounded-3 mt-2 visually-hidden", style: 'margin-left: 1vw;' %>
+
 
 
     <%= form_with url: search_products_path, method: :get, local: true, id: "barcode-form" do %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -13,6 +13,8 @@
     <% (@product.user_rating.to_i).times do %>
       <i class="fa-solid fa-star fs-2" style="color:#ffcc00;"></i>
     <% end %>
+    <p class="sr-only">User rating: <%= (@product.user_rating.to_i) %>out of 5</p>
+
     <h2 class="mb-3"><%= @product.retail_price == "$0.00" ? "Ask store associate" : @product.retail_price  %></h2>
     <div class="product-menu accordion accordion-flush" id="accordionFlushExample">
       <div class="accordion-item">

--- a/app/views/shared/_favorite.html.erb
+++ b/app/views/shared/_favorite.html.erb
@@ -5,7 +5,7 @@
   <% if user_signed_in? %>
     <% if current_user.favorited?(@product) %>
         <i id="favorited-heart" class="fa-solid fa-heart"></i>
-        <p id ="favorited-text" class="text-center">This product is in your favorites!</p>
+        <p id ="favorited-text" class="text-center" role='button'>Remove from your favorites</p>
     <% else %>
       <%= link_to favorite_product_path(@product),
         class: "favorite-container d-flex flex-column align-items-center",


### PR DESCRIPTION
The scanner page looks the same, but I have added some screen reader only instructions.

Here's what the screen reader will read once it gets on the page:

- Scanning in progress. 
- Place the product in front of the camera and rotate it slowly to find the QR code.
- If no product is found, you can call for assistance using the button below.
- Call for assistance - link

The last one is a hidden button, accessible to screen readers only. We may want to a more visible assistance button for every user though, maybe we can just highlight the one in the navbar? I think it should be obvious and easy to spot in every page. 